### PR TITLE
Validate CLI output arguments

### DIFF
--- a/lib/menus.sh
+++ b/lib/menus.sh
@@ -1,8 +1,36 @@
 # shellcheck shell=bash
+print_usage() {
+    echo "网络延迟检测工具 - 使用说明"
+    echo ""
+    echo "用法: $0 [选项]"
+    echo ""
+    echo "选项:"
+    echo "  --output-file <path>     指定输出文件路径"
+    echo "  --no-output              禁用文件输出"
+    echo "  --single-result-page     生成单页结果（HTML/Markdown）"
+    echo "  --format <type>          输出格式: text/markdown/html/json"
+    echo "  --help, -h               显示此帮助信息"
+    echo ""
+}
+
+validate_output_format() {
+    case "$1" in
+        text|markdown|html|json) return 0 ;;
+        *)
+            echo "错误: 不支持的输出格式 '$1'，可选: text/markdown/html/json" >&2
+            exit 1
+            ;;
+    esac
+}
+
 parse_arguments() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             --output-file)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "错误: --output-file 需要路径参数" >&2
+                    exit 1
+                fi
                 OUTPUT_FILE="$2"
                 ENABLE_OUTPUT=true
                 # 根据文件扩展名自动检测格式
@@ -23,26 +51,21 @@ parse_arguments() {
                 shift
                 ;;
             --format)
+                if [[ $# -lt 2 || "$2" == --* ]]; then
+                    echo "错误: --format 需要格式参数: text/markdown/html/json" >&2
+                    exit 1
+                fi
+                validate_output_format "$2"
                 OUTPUT_FORMAT="$2"
                 shift 2
                 ;;
             --help|-h)
-                echo "网络延迟检测工具 - 使用说明"
-                echo ""
-                echo "用法: $0 [选项]"
-                echo ""
-                echo "选项:"
-                echo "  --output-file <path>     指定输出文件路径"
-                echo "  --no-output              禁用文件输出"
-                echo "  --single-result-page     生成单页结果（HTML/Markdown）"
-                echo "  --format <type>          输出格式: text/markdown/html/json"
-                echo "  --help, -h               显示此帮助信息"
-                echo ""
+                print_usage
                 exit 0
                 ;;
             *)
-                echo "未知参数: $1"
-                echo "使用 --help 查看帮助"
+                echo "未知参数: $1" >&2
+                echo "使用 --help 查看帮助" >&2
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
## 问题
CLI 参数解析没有校验需要值的参数和输出格式：
- `--output-file` / `--format` 缺少参数时只会以非预期方式退出，错误不清晰。
- `--format xml` 这类未支持格式会继续进入依赖检查/交互菜单，非交互场景容易失败且原因不明确。

## 修复
- 提取 `print_usage`。
- 为 `--output-file` 和 `--format` 增加必填参数校验。
- 将 `--format` 限制为文档列出的 `text/markdown/html/json`。
- 未知参数错误输出到 stderr。

## 验证
- 原始验证：`bash -n $(git ls-files '*.sh')` 通过；`bash latency.sh --format xml` 会进入依赖检查/菜单后退出。
- 修复后验证：
  - `bash -n $(git ls-files '*.sh')` 通过。
  - `bash latency.sh --help` 通过。
  - `bash latency.sh --output-file` 返回非 0 且输出清晰错误。
  - `bash latency.sh --format xml` 返回非 0，且在依赖检查/菜单前输出清晰错误。

## 风险
会拒绝之前被静默接受的非文档输出格式；支持的格式与 README/help 中列出的格式一致。
